### PR TITLE
Update to GNOME 46

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -67,7 +67,7 @@ export default class QstExtension extends Extension {
         })
 
         // load menu item added tracker
-        this.menuItemAddedTracker = QuickSettingsGrid.connect("actor-added",()=>{
+        this.menuItemAddedTracker = QuickSettingsGrid.connect("child-added",()=>{
             if (this.updating) return
             this.updating = true
             for (const feature of this.features) {

--- a/src/libs/volumeMixerHandler.js
+++ b/src/libs/volumeMixerHandler.js
@@ -77,16 +77,16 @@ export const VolumeMixer = class VolumeMixer extends PopupMenu.PopupMenuSection 
             let sliderObj = sliderBox.get_children()[1]
             sliderBox.remove_child(sliderObj)
             sliderBox.remove_child(lastObj)
-            sliderBox.add(slider._vbox)
+            sliderBox.add_child(slider._vbox)
             
             slider._label = new St.Label({ x_expand: true })
             slider._label.style_class = "QSTWEAKS-volume-mixer-label"
             slider._label.text = name && this._showStreamDesc ? `${name} - ${description}` : (name || description)
-            slider._vbox.add(slider._label)
-            slider._vbox.add(sliderObj)
+            slider._vbox.add_child(slider._label)
+            slider._vbox.add_child(sliderObj)
         }
 
-        this.actor.add(slider)
+        this.actor.add_child(slider)
         slider.visible = true
     }
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,7 +2,7 @@
   "description": "Let's tweak gnome 43's quick settings! You can add Media Controls, Notifications, Volume Mixer on quick settings and remove useless buttons!",
   "name": "[QSTweak] Quick Setting Tweaker",
   "url": "https://github.com/qwreey75/quick-settings-tweaks",
-  "shell-version": ["45"],
+  "shell-version": ["45", "46"],
   "uuid": "quick-settings-tweaks@qwreey",
   "settings-schema": "org.gnome.shell.extensions.quick-settings-tweaks",
   "gettext-domain": "quick-settings-tweaks"


### PR DESCRIPTION
Gnome 46 deprecates add_actor and actor-added. This PR replaces uses of them with add_child and child-added.
This is my first time working on an extension, so let me know if I did anything incorrectly!