### PR TITLE
Fix missing icon in dnd toggle when it's turned off

### DIFF
--- a/src/features/toggle/dndQuickToggle.ts
+++ b/src/features/toggle/dndQuickToggle.ts
@@ -28,7 +28,7 @@ class DndQuickToggle extends QuickToggle {
 		this.iconName =
 			this.checked
 			? "notifications-disabled-symbolic"
-			: "notifications-symbolic"
+			: "org.gnome.Settings-notifications-symbolic"
 	}
 
 	// Toggle DND Mode


### PR DESCRIPTION
Fixes #182 by using the correct icon name.