### PR TITLE
Improve media gradient handling, make media widget show more reliably

### DIFF
--- a/src/features/widget/media.ts
+++ b/src/features/widget/media.ts
@@ -651,15 +651,12 @@ class MediaItem extends MessageList.Message {
 
 		if (coverUrl.startsWith("file://")) {
 			const coverPath = decodeURIComponent(coverUrl.replace(/^file:\/\//,""))
-			console.log("MediaItem", "get color from file", coverPath);
 			colorTask = this._cachedColors.get(coverPath)
 			if (!colorTask) {
-				console.log("MediaItem", "get color from file, not in cache", coverPath);
 				let pixbuf: GdkPixbuf.Pixbuf;
 				try {
 					pixbuf = GdkPixbuf.Pixbuf.new_from_file(coverPath)
 				} catch (error) {
-					console.log("MediaItem", "get color from file failed", coverPath, error);
 					return
 				}  finally {
 					if (!pixbuf) {
@@ -671,11 +668,9 @@ class MediaItem extends MessageList.Message {
 			}
 		} else if (coverUrl.startsWith("https://") || coverUrl.startsWith("http://")) {
 			const coverPath = decodeURIComponent(coverUrl.replace(/^https?:\/\//,"").replace(/^http?:\/\//,""))
-			console.log("MediaItem", "get color from url", coverPath);
 			colorTask = this._cachedColors.get(coverPath)
 
 			if (!colorTask) {
-				console.log("MediaItem", "get color from url, not in cache", coverPath);
 				const session = new Soup.Session();
 				const uri = GLib.Uri.parse(coverUrl, GLib.UriFlags.NONE);
 				const message = new Soup.Message({method: 'GET', uri});
@@ -689,7 +684,6 @@ class MediaItem extends MessageList.Message {
 						return getImageMeanColor(pixbuf);
 					})
 					.catch(error => {
-						console.error("MediaItem: Failed to load image:", error);
 						return null;
 					});
 

--- a/src/features/widget/media.ts
+++ b/src/features/widget/media.ts
@@ -5,6 +5,7 @@ import GLib from "gi://GLib"
 import Gio from "gi://Gio"
 import GdkPixbuf from "gi://GdkPixbuf"
 import Shell from "gi://Shell"
+import Soup from 'gi://Soup';
 import * as Main from "resource:///org/gnome/shell/ui/main.js"
 import * as MessageList from "resource:///org/gnome/shell/ui/messageList.js"
 import { loadInterfaceXML } from "resource:///org/gnome/shell/misc/fileUtils.js"
@@ -644,24 +645,55 @@ class MediaItem extends MessageList.Message {
 		// Push get color task, use cache if possible
 		this._cachedColors ??= new Map()
 		const coverUrl = this._player.trackCoverUrl
+		let colorTask;
+
 		if (!coverUrl || coverUrl.endsWith(".svg")) return
-		const coverPath = coverUrl.replace(/^file:\/\//,"")
-		console.log("MediaItem", "get color from file", coverPath);
-		let colorTask = this._cachedColors.get(coverPath)
-		if (!colorTask) {
-			console.log("MediaItem", "get color from file, not in cache", coverPath);
-			let pixbuf: GdkPixbuf.Pixbuf;
-			try {
-				pixbuf = GdkPixbuf.Pixbuf.new_from_file(coverPath)
-			} catch (error) {
-				console.log("MediaItem", "get color from file failed", coverPath, error);
-				return
-			}  finally {
-				if (!pixbuf) {
+
+		if (coverUrl.startsWith("file://")) {
+			const coverPath = decodeURIComponent(coverUrl.replace(/^file:\/\//,""))
+			console.log("MediaItem", "get color from file", coverPath);
+			colorTask = this._cachedColors.get(coverPath)
+			if (!colorTask) {
+				console.log("MediaItem", "get color from file, not in cache", coverPath);
+				let pixbuf: GdkPixbuf.Pixbuf;
+				try {
+					pixbuf = GdkPixbuf.Pixbuf.new_from_file(coverPath)
+				} catch (error) {
+					console.log("MediaItem", "get color from file failed", coverPath, error);
 					return
+				}  finally {
+					if (!pixbuf) {
+						return
+					}
+					colorTask = getImageMeanColor(pixbuf)
+					this._cachedColors.set(coverPath, colorTask)
 				}
-				colorTask = getImageMeanColor(pixbuf)
-				this._cachedColors.set(coverPath, colorTask)
+			}
+		} else if (coverUrl.startsWith("https://") || coverUrl.startsWith("http://")) {
+			const coverPath = decodeURIComponent(coverUrl.replace(/^https?:\/\//,"").replace(/^http?:\/\//,""))
+			console.log("MediaItem", "get color from url", coverPath);
+			colorTask = this._cachedColors.get(coverPath)
+
+			if (!colorTask) {
+				console.log("MediaItem", "get color from url, not in cache", coverPath);
+				const session = new Soup.Session();
+				const uri = GLib.Uri.parse(coverUrl, GLib.UriFlags.NONE);
+				const message = new Soup.Message({method: 'GET', uri});
+
+				colorTask = session.send_and_read_async(message, null, null)
+					.then(img_bytes => {
+						if (!img_bytes) throw new Error("No image data received");
+						
+						const stream = Gio.MemoryInputStream.new_from_bytes(img_bytes);
+						const pixbuf = GdkPixbuf.Pixbuf.new_from_stream(stream, null);
+						return getImageMeanColor(pixbuf);
+					})
+					.catch(error => {
+						console.error("MediaItem: Failed to load image:", error);
+						return null;
+					});
+
+				this._cachedColors.set(coverPath, colorTask);
 			}
 		}
 


### PR DESCRIPTION
Should fix #185.

Currently, the extension only supports raw file URIs when updating the gradient. If the MPRIS `artUrl` is an encoded URI or a remote URL, gradient creation fails and the media widget does not show.
When creating the progress indicator, the MPRIS `length` is expected to be an int64, but some apps store it as a `uint64` instead. This causes the progress bar to not work properly.

This PR makes URI be decoded via `decodeURIComponent` before accessing them and adds an HTTP client using `Soup` to download web album art, as well as making the media widget show without a gradient if it is unable to create one.
Additionally, it unpacks the track length using `deepUnpack` to support both ints and uints.