### PR TITLE
Add Support for GNOME 48

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -1054,14 +1054,6 @@ msgstr ""
 msgid "Adjust Date Menu layout"
 msgstr ""
 
-#: target/out/prefPages/layout.js:828
-msgid "Hide Notifications"
-msgstr ""
-
-#: target/out/prefPages/layout.js:829
-msgid "Hide notifications on the date menu"
-msgstr ""
-
 #: target/out/prefPages/layout.js:834
 msgid "Hide Media Control"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -1052,14 +1052,6 @@ msgstr ""
 msgid "Adjust Date Menu layout"
 msgstr ""
 
-#: target/out/prefPages/layout.js:828
-msgid "Hide Notifications"
-msgstr ""
-
-#: target/out/prefPages/layout.js:829
-msgid "Hide notifications on the date menu"
-msgstr ""
-
 #: target/out/prefPages/layout.js:834
 msgid "Hide Media Control"
 msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -1060,14 +1060,6 @@ msgstr ""
 msgid "Adjust Date Menu layout"
 msgstr ""
 
-#: target/out/prefPages/layout.js:828
-msgid "Hide Notifications"
-msgstr ""
-
-#: target/out/prefPages/layout.js:829
-msgid "Hide notifications on the date menu"
-msgstr ""
-
 #: target/out/prefPages/layout.js:834
 msgid "Hide Media Control"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -1056,14 +1056,6 @@ msgstr ""
 msgid "Adjust Date Menu layout"
 msgstr ""
 
-#: target/out/prefPages/layout.js:828
-msgid "Hide Notifications"
-msgstr ""
-
-#: target/out/prefPages/layout.js:829
-msgid "Hide notifications on the date menu"
-msgstr ""
-
 #: target/out/prefPages/layout.js:834
 msgid "Hide Media Control"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -1080,14 +1080,6 @@ msgstr "달력 메뉴"
 msgid "Adjust Date Menu layout"
 msgstr "달력 메뉴의 레이아웃을 조절합니다"
 
-#: target/out/prefPages/layout.js:828
-msgid "Hide Notifications"
-msgstr "알림 숨김"
-
-#: target/out/prefPages/layout.js:829
-msgid "Hide notifications on the date menu"
-msgstr "알림을 날짜 메뉴에서 숨깁니다"
-
 #: target/out/prefPages/layout.js:834
 msgid "Hide Media Control"
 msgstr "미디어 컨트롤 숨김"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1087,14 +1087,6 @@ msgstr "Data"
 msgid "Adjust Date Menu layout"
 msgstr "Dostosuj układ menu daty"
 
-#: target/out/prefPages/layout.js:828
-msgid "Hide Notifications"
-msgstr "Przestrzeń powiadomień"
-
-#: target/out/prefPages/layout.js:829
-msgid "Hide notifications on the date menu"
-msgstr "Ukryj przestrzeń powiadomień"
-
 #: target/out/prefPages/layout.js:834
 msgid "Hide Media Control"
 msgstr "Sterowanie mediami"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1062,14 +1062,6 @@ msgstr ""
 msgid "Adjust Date Menu layout"
 msgstr ""
 
-#: target/out/prefPages/layout.js:828
-msgid "Hide Notifications"
-msgstr ""
-
-#: target/out/prefPages/layout.js:829
-msgid "Hide notifications on the date menu"
-msgstr ""
-
 #: target/out/prefPages/layout.js:834
 msgid "Hide Media Control"
 msgstr ""

--- a/po/quick-settings-tweaks@qwreey.pot
+++ b/po/quick-settings-tweaks@qwreey.pot
@@ -1079,14 +1079,6 @@ msgstr ""
 msgid "Adjust Date Menu layout"
 msgstr ""
 
-#: target/out/prefPages/layout.js:828
-msgid "Hide Notifications"
-msgstr ""
-
-#: target/out/prefPages/layout.js:829
-msgid "Hide notifications on the date menu"
-msgstr ""
-
 #: target/out/prefPages/layout.js:834
 msgid "Hide Media Control"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -1088,14 +1088,6 @@ msgstr ""
 msgid "Adjust Date Menu layout"
 msgstr ""
 
-#: target/out/prefPages/layout.js:828
-msgid "Hide Notifications"
-msgstr ""
-
-#: target/out/prefPages/layout.js:829
-msgid "Hide notifications on the date menu"
-msgstr ""
-
 #: target/out/prefPages/layout.js:834
 msgid "Hide Media Control"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -1062,14 +1062,6 @@ msgstr ""
 msgid "Adjust Date Menu layout"
 msgstr ""
 
-#: target/out/prefPages/layout.js:828
-msgid "Hide Notifications"
-msgstr ""
-
-#: target/out/prefPages/layout.js:829
-msgid "Hide notifications on the date menu"
-msgstr ""
-
 #: target/out/prefPages/layout.js:834
 msgid "Hide Media Control"
 msgstr ""

--- a/schemas/org.gnome.shell.extensions.quick-settings-tweaks.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.quick-settings-tweaks.gschema.xml
@@ -263,9 +263,6 @@
     <key name="datemenu-disable-menu" type="b">
       <default>false</default>
     </key>
-    <key name="datemenu-hide-notifications" type="b">
-      <default>true</default>
-    </key>
     <key name="datemenu-hide-media-control" type="b">
       <default>true</default>
     </key>

--- a/src/features/layout/dateMenu.ts
+++ b/src/features/layout/dateMenu.ts
@@ -82,11 +82,6 @@ export class DateMenuLayoutFeature extends FeatureBase {
 		}
 	}
 	override onUnload(): void {
-                for (const mediaMessage of Global.MediaMessages) {
-                    mediaMessage.show();
-                }
-		if ((Global.NotificationSection as any)._shouldShow()) Global.NotificationSection.show()
-
 		// Remove modified styles
 		const style = new StyleClass((Global.DateMenuBox as any).style_class)
 			.remove("QSTWEAKS-hide-right-box")

--- a/src/features/layout/dateMenu.ts
+++ b/src/features/layout/dateMenu.ts
@@ -6,13 +6,11 @@ import Logger from "../../libs/shared/logger.js"
 export class DateMenuLayoutFeature extends FeatureBase {
 	// #region settings
 	hideMediaControl: boolean
-	hideNotifications: boolean
 	hideLeftBox: boolean
 	hideRightBox: boolean
 	disableMenu: boolean
 	override loadSettings(loader: SettingLoader): void {
 		this.hideMediaControl = loader.loadBoolean("datemenu-hide-media-control")
-		this.hideNotifications = loader.loadBoolean("datemenu-hide-notifications")
 		this.hideLeftBox = loader.loadBoolean("datemenu-hide-left-box")
 		this.hideRightBox = loader.loadBoolean("datemenu-hide-right-box")
 		this.disableMenu = loader.loadBoolean("datemenu-disable-menu")
@@ -30,14 +28,6 @@ export class DateMenuLayoutFeature extends FeatureBase {
                                         ()=>true
                                 )
                         }
-		}
-
-		// Hide notifications from date menu
-		if (this.hideNotifications) {
-			this.maid.hideJob(
-				Global.NotificationSection,
-				()=>true
-			)
 		}
 
 		// Hide left box from date menu

--- a/src/features/layout/dateMenu.ts
+++ b/src/features/layout/dateMenu.ts
@@ -24,10 +24,12 @@ export class DateMenuLayoutFeature extends FeatureBase {
 
 		// Hide media control from date menu
 		if (this.hideMediaControl) {
-			this.maid.hideJob(
-				Global.MediaSection,
-				()=>true
-			)
+                        for (const mediaMessage of Global.MediaMessages) {
+                                this.maid.hideJob(
+                                        mediaMessage,
+                                        ()=>true
+                                )
+                        }
 		}
 
 		// Hide notifications from date menu
@@ -80,7 +82,9 @@ export class DateMenuLayoutFeature extends FeatureBase {
 		}
 	}
 	override onUnload(): void {
-		if ((Global.MediaSection as any)._shouldShow()) Global.MediaSection.show()
+                for (const mediaMessage of Global.MediaMessages) {
+                    mediaMessage.show();
+                }
 		if ((Global.NotificationSection as any)._shouldShow()) Global.NotificationSection.show()
 
 		// Remove modified styles

--- a/src/features/widget/notifications.ts
+++ b/src/features/widget/notifications.ts
@@ -169,7 +169,7 @@ GObject.registerClass(NativeControl)
 // #endregion NativeControl
 
 // #region NotificationList
-class NotificationList extends MessageList.MessageListSection {
+class NotificationList extends MessageList.NotificationMessageGroup {
 	_nUrgent: number
 
 	_init() {

--- a/src/global.ts
+++ b/src/global.ts
@@ -11,7 +11,7 @@ import {
 	type NotificationSection,
 	type CalendarMessageList
 } from "resource:///org/gnome/shell/ui/calendar.js";
-import { type MediaSection } from "resource:///org/gnome/shell/ui/mpris.js"
+import { type MediaMessage } from "resource:///org/gnome/shell/ui/messageList.js"
 import {
 	type SystemItem,
 	type Indicator as SystemIndicator
@@ -69,8 +69,8 @@ const Global = new (class Global {
 	get NotificationSection(): NotificationSection {
 		return (this.DateMenu as any)._messageList._notificationSection
 	}
-	get MediaSection(): MediaSection {
-		return (this.DateMenu as any)._messageList._mediaSection
+	get MediaMessages(): MediaMessage[] {
+		return [...((this.DateMenu as any)._messageList._messageView._playerToMessage.values())]
 	}
 	get DateMenuIndicator(): Clutter.Actor {
 		return (this.DateMenu as any)._indicator

--- a/src/prefPages/layout.ts
+++ b/src/prefPages/layout.ts
@@ -891,12 +891,6 @@ export const LayoutPage = GObject.registerClass({
 		},[
 			SwitchRow({
 				settings,
-				title: _("Hide Notifications"),
-				subtitle: _("Hide notifications on the date menu"),
-				bind: "datemenu-hide-notifications",
-			}),
-			SwitchRow({
-				settings,
 				title: _("Hide Media Control"),
 				subtitle: _("Hide media control on the date menu"),
 				bind: "datemenu-hide-media-control",


### PR DESCRIPTION
Aims to add support for GNOME 48, fixing #197, #171 and #176.

Currently stuck at a necessary design decision.

## Guide to Changes

### [Fixed] Problem 1 - `MessageListSection` Unsupported

The first problem, fixed in f8a9c23, was to migrate from `MessageListSection` to `NotificationMessageGroup`, which is an expansion of the former.

### [Decision Pending] Problem 2 - Handling `MediaSection` and `NotificationSection`

Notification handling is changed significantly in GNOME 48. Earlier, the datemenu message list (`Main.panel.statusArea.dateMenu._messageList`) had different sections (visual elements) for currently playing media "notifications" (`._mediaSection`) and normal notifications (`._notificationSection`).

Now, it only has one "section" (`._messageView`) containing all notifications (`._messageView.messages` of type `NotificationMessageGroup[]`), including media messages (of type `MediaMessage`), basically ending all distinction. The only link here is `._messageView._playerToMessage`, a map from `string`s to corresponding `MediaMessage`s. Note that the new `._messageView._mediaSource` and `._messageView._mediaSource._players` are useless here because they don't contain or point to any visual elements, only information.

This reduces to two related problems: hiding sections in the datemenu, and moving notifications to the system tray.

#### Problem 2.1 - Hiding Sections

The extension currently allows hiding (1) notifications, (2) media notifications/section or (3) the whole left box. This was easy when there were two sections in the message list. With only one "section" left, (1) and (2) need some dexterity. 9a7bbf8 achieves (1) by using the method mentioned above (with issues). (2) is possible, but doesn't have any clean solution. One would have to go through the `messages` array and hide each individual visual notification element (ugh). Another option is to hide `._messageView` altogether. This results in a completely empty left box, might as well just remove it as in (3).

#### Problem 2.2 - Moving Notifications to System Tray

Please let me know if I get something wrong in this section. Because the media widget in the system tray works using MPRIS independent from `._mediaSection`, it is unaffected and works normally. The notification widget, however, used to simply move the notification section element from the datemenu to the system tray. That section no longer exists, making this method no longer possible. `._messageView` also doesn't have the same interface as the earlier `._notificationSection`. Finding the correct place to plug the signals being used correctly will need some digging. However, one possibility is to move the `._messageView` instead, and hide the media messages, as 9a7bbf8 does, resulting in something similar to the current notification section. 

#### Decision

The issue here is that when it comes to hiding sections, (2) above no longer has a clean solution, and I would suggest dropping it entirely, meaning users can't hide normal notifications while continuing to see the media notification (if anyone even uses this combination). The options for them would then be to (1) hide the media notification, (2) hide everything (all notifications), and possibly (3) hide the left box. The difference between (2) and (3) is the presence of an empty left box. That's my opinion. What would you suggest?

I haven't gotten around to problem 2.2 because I was testing hiding the media notifications in isolation but the extension was crashing as mentioned above "(with issues)". Going forward with anything needs this decision handled first.
