### PR TITLE
Adds a workflow to build extension in every commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build extension
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          DEBIAN_FRONTEND=noninteractive sudo apt install -y gettext gnome-shell
+      - name: Build extension
+        run: |
+          npm i
+          ./install.sh build
+      - name: Archive current compilation
+        uses: actions/upload-artifact@v4
+        with:
+          name: "quick-settings-tweaks-${{ github.sha }}"
+          path: "target/quick-settings-tweaks@qwreey.shell-extension.zip"


### PR DESCRIPTION
A simple workflow is added that builds the extension in each commit and stores it as an artifact. This allows users who create issues to be redirected to a specific compilation so they can download the extension that has already been created and test it.

You can see how it looks [here](https://github.com/ogarcia/quick-settings-tweaks/actions/runs/18339364095).