### PR TITLE
fix: GNOME 49 compatibility - Replace DoNotDisturbSwitch and fix bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@girs/gjs": "^4.0.0-beta.38",
-        "@girs/gnome-shell": "^49.0.1"
+        "@girs/gnome-shell": "^49.1.0"
       },
       "devDependencies": {
         "sass": "^1.83.4",
@@ -18,193 +18,39 @@
       }
     },
     "node_modules/@girs/accountsservice-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/accountsservice-1.0/-/accountsservice-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-ASp942wWTf+FDpJ0oTVCGwQyR2q/hMitr1X9m/QbOiCqq65G893eevnB9TKutMeWM6iG3rp0xDKcM+kRUVEK2g==",
+      "version": "1.0.0-4.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@girs/accountsservice-1.0/-/accountsservice-1.0-1.0.0-4.0.0-beta.38.tgz",
+      "integrity": "sha512-6QzytM5dztmMynF2bxN73EuNK9ArMFxkP2L8wUC7IH45zBeBOfYcqL85BFh2PmkGmqRk+Rli5EFR8dAkx3Ig5Q==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/accountsservice-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-uQqDNDoDVALwSIRoW4I6Y9GXsQ9vkQLxB5kr2vQIskIW9fw6VExLpjPuyoVfRO8UqD3bU0d67uLWy6hCcnA0EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/accountsservice-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-rot40meT8+BuvcVDOQP02GZzWBH4pe4jO935g687jZ4mc0xkOFxDoxiSrif/+rb8VplDswKcu9AVQ1H59Z1Tiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/accountsservice-1.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Aj/QB0Eab8vkiP3doISBLAP6+GZhqBkc2EcjYymUxr/3VZpmpOTdFs4DFURUHKg4kkbwRfJSUrXEuTLSGcMfww==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/accountsservice-1.0/node_modules/@girs/glib-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Ljjr//wuJHjSE6UbuoYZ63I5u/qM1Am+fADzfJB2wUtelsfCjQVy7Gsucaef0oLW5nu9+kylLS+6LsQULx2ouw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/accountsservice-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-0SPLcXOwHauSWBoNZ/CtcmGd5Yn9NZYVgznMTGMnesWdUqD3BH5Ykdf9DTAEujxirJuLlxsPAH5lpR9zWRp8PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/accountsservice-1.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-UI35nVCQgjNvE+3Q+NeISsOOvynytagitURj2+hUGoCCp/BRMxqm6tUtX2hdhCeWUtd971/gLm78YjucAxRmWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37"
+        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gjs": "4.0.0-beta.38",
+        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/adw-1": {
-      "version": "1.8.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/adw-1/-/adw-1-1.8.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-QXnbGlQ0yi+w9ItPL0sMOws3fZEoiVhib1pnSn8ZTeKA32/JTylu8em6rEaMBaV1X/9vUV0NmPW5jKFCxidxQQ==",
+      "version": "1.9.0-4.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@girs/adw-1/-/adw-1-1.9.0-4.0.0-beta.38.tgz",
+      "integrity": "sha512-d9tPlKWLpI3gEz72s1G3tX57nNCQjLopOy6I3CNucOmqlF2PFC4f+Ubq8BOMrVFqbTOl/HkAu7vfGuRP+FjHNQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-beta.37",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gsk-4.0": "4.0.0-4.0.0-beta.37",
-        "@girs/gtk-4.0": "4.20.1-4.0.0-beta.37",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.37",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.37",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/adw-1/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-uQqDNDoDVALwSIRoW4I6Y9GXsQ9vkQLxB5kr2vQIskIW9fw6VExLpjPuyoVfRO8UqD3bU0d67uLWy6hCcnA0EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/adw-1/node_modules/@girs/gio-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-rot40meT8+BuvcVDOQP02GZzWBH4pe4jO935g687jZ4mc0xkOFxDoxiSrif/+rb8VplDswKcu9AVQ1H59Z1Tiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/adw-1/node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Aj/QB0Eab8vkiP3doISBLAP6+GZhqBkc2EcjYymUxr/3VZpmpOTdFs4DFURUHKg4kkbwRfJSUrXEuTLSGcMfww==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/adw-1/node_modules/@girs/glib-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Ljjr//wuJHjSE6UbuoYZ63I5u/qM1Am+fADzfJB2wUtelsfCjQVy7Gsucaef0oLW5nu9+kylLS+6LsQULx2ouw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/adw-1/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-0SPLcXOwHauSWBoNZ/CtcmGd5Yn9NZYVgznMTGMnesWdUqD3BH5Ykdf9DTAEujxirJuLlxsPAH5lpR9zWRp8PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/adw-1/node_modules/@girs/gobject-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-UI35nVCQgjNvE+3Q+NeISsOOvynytagitURj2+hUGoCCp/BRMxqm6tUtX2hdhCeWUtd971/gLm78YjucAxRmWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/adw-1/node_modules/@girs/gtk-4.0": {
-      "version": "4.20.1-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gtk-4.0/-/gtk-4.0-4.20.1-4.0.0-beta.37.tgz",
-      "integrity": "sha512-cHsgT4o03ISGqL2PAEWLHb5AO4C7gQR/9whnwXhZ7KxfEXhJWNt6TkxSg0iopNT8OuXlxkQghilxRtp6ue/6xQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-beta.37",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gsk-4.0": "4.0.0-4.0.0-beta.37",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.37",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.37",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.37"
+        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
+        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gdk-4.0": "4.0.0-4.0.0-beta.38",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gjs": "4.0.0-beta.38",
+        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/graphene-1.0": "1.0.0-4.0.0-beta.38",
+        "@girs/gsk-4.0": "4.0.0-4.0.0-beta.38",
+        "@girs/gtk-4.0": "4.20.1-4.0.0-beta.38",
+        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
+        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/atk-1.0": {
@@ -251,55 +97,6 @@
         "@girs/pango-1.0": "1.57.0-4.0.0-beta.38"
       }
     },
-    "node_modules/@girs/clutter-17/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-543dlQheKHSVWIatqHNBiLceIWYzIJDXvofR3PfgarKMMi0IRkn1TndzxUxsLC4Eu24KgOKGZYjU1YPUMVGbgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/clutter-17/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-zqCyLXFqsOJtCnwUR6lI6HBVdaJ6aKsA25y+6xK2dFO/NChOjH0hmBuVyTQiyLe+4jGW700o+uYIYlrpEXT/7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/clutter-17/node_modules/@girs/harfbuzz-0.0": {
-      "version": "11.5.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-11.5.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-XRf/neZYpEkinNZ8SCRKIao3RNVJzMeYcjuO1b1tbqVCrN7uVZ+MIaDW5NjWKi0K6IQSyZWdDgkzrtOrIN4CWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/clutter-17/node_modules/@girs/pango-1.0": {
-      "version": "1.57.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-fnTzVVhKb4XjGrnuqk9X++KDe2bk84Hg5472O2UrtIT1A6dzMS6gWhSvaw0ULZH/Ypj9WN12B0oceWynR6unLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38"
-      }
-    },
     "node_modules/@girs/cogl-17": {
       "version": "17.0.0-4.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@girs/cogl-17/-/cogl-17-17.0.0-4.0.0-beta.38.tgz",
@@ -312,17 +109,6 @@
         "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
         "@girs/graphene-1.0": "1.0.0-4.0.0-beta.38",
         "@girs/mtk-17": "17.0.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/cogl-17/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-zqCyLXFqsOJtCnwUR6lI6HBVdaJ6aKsA25y+6xK2dFO/NChOjH0hmBuVyTQiyLe+4jGW700o+uYIYlrpEXT/7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/cogl-2.0": {
@@ -338,79 +124,13 @@
       }
     },
     "node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-mIuT7sTqcEt3hKkqG5pVEYd8LbbFdUgUuPVZbO5LGdNZjGnWaxwffZUPA0F5Ynw3wTZY3YZn1Z3WccE+aMmOPA==",
+      "version": "2.0.0-4.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.38.tgz",
+      "integrity": "sha512-543dlQheKHSVWIatqHNBiLceIWYzIJDXvofR3PfgarKMMi0IRkn1TndzxUxsLC4Eu24KgOKGZYjU1YPUMVGbgg==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/freetype2-2.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-uQqDNDoDVALwSIRoW4I6Y9GXsQ9vkQLxB5kr2vQIskIW9fw6VExLpjPuyoVfRO8UqD3bU0d67uLWy6hCcnA0EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/freetype2-2.0/node_modules/@girs/gio-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-rot40meT8+BuvcVDOQP02GZzWBH4pe4jO935g687jZ4mc0xkOFxDoxiSrif/+rb8VplDswKcu9AVQ1H59Z1Tiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/freetype2-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Aj/QB0Eab8vkiP3doISBLAP6+GZhqBkc2EcjYymUxr/3VZpmpOTdFs4DFURUHKg4kkbwRfJSUrXEuTLSGcMfww==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/freetype2-2.0/node_modules/@girs/glib-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Ljjr//wuJHjSE6UbuoYZ63I5u/qM1Am+fADzfJB2wUtelsfCjQVy7Gsucaef0oLW5nu9+kylLS+6LsQULx2ouw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/freetype2-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-0SPLcXOwHauSWBoNZ/CtcmGd5Yn9NZYVgznMTGMnesWdUqD3BH5Ykdf9DTAEujxirJuLlxsPAH5lpR9zWRp8PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/freetype2-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-UI35nVCQgjNvE+3Q+NeISsOOvynytagitURj2+hUGoCCp/BRMxqm6tUtX2hdhCeWUtd971/gLm78YjucAxRmWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37"
+        "@girs/gjs": "4.0.0-beta.38",
+        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/gck-2": {
@@ -451,167 +171,35 @@
       }
     },
     "node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-FhIfLL4WlgcGbML1SH3LgZDM3zdgIECsxgXa5dUP9PJtFsfgOyEiZUcrpm3kUhWOxAP2QLfchEqxtATI3sH4ow==",
+      "version": "4.0.0-4.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-beta.38.tgz",
+      "integrity": "sha512-hk6SG4pCcezKp2VNxJc0TC1gkZe3C8shD8sRQ3bUGyWl/9581WM2/8UU+W6fOf3SwXA1hquN6d3SjKbqkFNRKg==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.37",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.37",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-uQqDNDoDVALwSIRoW4I6Y9GXsQ9vkQLxB5kr2vQIskIW9fw6VExLpjPuyoVfRO8UqD3bU0d67uLWy6hCcnA0EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-rot40meT8+BuvcVDOQP02GZzWBH4pe4jO935g687jZ4mc0xkOFxDoxiSrif/+rb8VplDswKcu9AVQ1H59Z1Tiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdk-4.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Aj/QB0Eab8vkiP3doISBLAP6+GZhqBkc2EcjYymUxr/3VZpmpOTdFs4DFURUHKg4kkbwRfJSUrXEuTLSGcMfww==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdk-4.0/node_modules/@girs/glib-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Ljjr//wuJHjSE6UbuoYZ63I5u/qM1Am+fADzfJB2wUtelsfCjQVy7Gsucaef0oLW5nu9+kylLS+6LsQULx2ouw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-0SPLcXOwHauSWBoNZ/CtcmGd5Yn9NZYVgznMTGMnesWdUqD3BH5Ykdf9DTAEujxirJuLlxsPAH5lpR9zWRp8PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdk-4.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-UI35nVCQgjNvE+3Q+NeISsOOvynytagitURj2+hUGoCCp/BRMxqm6tUtX2hdhCeWUtd971/gLm78YjucAxRmWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37"
+        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
+        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gjs": "4.0.0-beta.38",
+        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
+        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-TX+m4+3twz/Ws1MkwpOcqi5lNpjU7tTq+gTuXCHSrZacfXJxxS3X+yMQgMGbPqEv4aIdj/t+Fjz9zExLa9oRiA==",
+      "version": "2.0.0-4.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-beta.38.tgz",
+      "integrity": "sha512-L8NE18rhj100lRGMnf7lNUdr6pHw2co1UtExxDnglba5lNee4NoyF/u8g4Mk3toPU0fAu+ug91HJ4o2mIJd7MQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-uQqDNDoDVALwSIRoW4I6Y9GXsQ9vkQLxB5kr2vQIskIW9fw6VExLpjPuyoVfRO8UqD3bU0d67uLWy6hCcnA0EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gio-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-rot40meT8+BuvcVDOQP02GZzWBH4pe4jO935g687jZ4mc0xkOFxDoxiSrif/+rb8VplDswKcu9AVQ1H59Z1Tiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Aj/QB0Eab8vkiP3doISBLAP6+GZhqBkc2EcjYymUxr/3VZpmpOTdFs4DFURUHKg4kkbwRfJSUrXEuTLSGcMfww==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/glib-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Ljjr//wuJHjSE6UbuoYZ63I5u/qM1Am+fADzfJB2wUtelsfCjQVy7Gsucaef0oLW5nu9+kylLS+6LsQULx2ouw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-0SPLcXOwHauSWBoNZ/CtcmGd5Yn9NZYVgznMTGMnesWdUqD3BH5Ykdf9DTAEujxirJuLlxsPAH5lpR9zWRp8PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gdkpixbuf-2.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-UI35nVCQgjNvE+3Q+NeISsOOvynytagitURj2+hUGoCCp/BRMxqm6tUtX2hdhCeWUtd971/gLm78YjucAxRmWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37"
+        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gjs": "4.0.0-beta.38",
+        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/gdm-1.0": {
@@ -696,35 +284,35 @@
       }
     },
     "node_modules/@girs/gnome-shell": {
-      "version": "49.0.1",
-      "resolved": "https://registry.npmjs.org/@girs/gnome-shell/-/gnome-shell-49.0.1.tgz",
-      "integrity": "sha512-n+Ms3k10cjGav7d2bBfzf2pJIlekOAM8xJd6qHK7uInwCtUoqJHWY/nwxmda5nJGf9xEHTHZcBrvJ2EVNHswlA==",
+      "version": "49.1.0",
+      "resolved": "https://registry.npmjs.org/@girs/gnome-shell/-/gnome-shell-49.1.0.tgz",
+      "integrity": "sha512-14Re6+DIrozWOErzW9fqvTAn0o9/1rMZuSDQ7BPIC+MYxmNmIlqzjo0kecbkXMN4ZY1zRpgfahbkiFwjJYZmfQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/accountsservice-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/adw-1": "^1.8.0-4.0.0-beta.37",
-        "@girs/atk-1.0": "^2.58.0-4.0.0-beta.37",
-        "@girs/clutter-17": "^17.0.0-4.0.0-beta.37",
-        "@girs/cogl-2.0": "^2.0.0-4.0.0-beta.37",
-        "@girs/gcr-4": "^4.4.0-4.0.0-beta.37",
-        "@girs/gdm-1.0": "^1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "^2.86.0-4.0.0-beta.37",
-        "@girs/giounix-2.0": "^2.0.0-4.0.0-beta.37",
-        "@girs/gjs": "^4.0.0-beta.37",
-        "@girs/glib-2.0": "^2.86.0-4.0.0-beta.37",
-        "@girs/gnomebg-4.0": "^4.0.0-4.0.0-beta.37",
-        "@girs/gnomebluetooth-3.0": "^3.0.0-4.0.0-beta.37",
-        "@girs/gnomedesktop-4.0": "^4.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "^2.86.0-4.0.0-beta.37",
-        "@girs/gtk-4.0": "^4.20.1-4.0.0-beta.37",
-        "@girs/gvc-1.0": "^1.0.0-4.0.0-beta.37",
-        "@girs/meta-17": "^17.0.0-4.0.0-beta.37",
-        "@girs/mtk-17": "^17.0.0-4.0.0-beta.37",
-        "@girs/polkit-1.0": "^1.0.0-4.0.0-beta.37",
-        "@girs/shell-17": "^17.0.0-4.0.0-beta.37",
-        "@girs/shew-0": "^0.0.0-4.0.0-beta.37",
-        "@girs/st-17": "^17.0.0-4.0.0-beta.37",
-        "@girs/upowerglib-1.0": "^0.99.1-4.0.0-beta.37"
+        "@girs/accountsservice-1.0": "1.0.0-4.0.0-beta.38",
+        "@girs/adw-1": "^1.9.0-4.0.0-beta.38",
+        "@girs/atk-1.0": "^2.58.0-4.0.0-beta.38",
+        "@girs/clutter-17": "^17.0.0-4.0.0-beta.38",
+        "@girs/cogl-2.0": "^2.0.0-4.0.0-beta.38",
+        "@girs/gcr-4": "^4.4.0-4.0.0-beta.38",
+        "@girs/gdm-1.0": "^1.0.0-4.0.0-beta.38",
+        "@girs/gio-2.0": "^2.86.0-4.0.0-beta.38",
+        "@girs/giounix-2.0": "^2.0.0-4.0.0-beta.38",
+        "@girs/gjs": "^4.0.0-beta.38",
+        "@girs/glib-2.0": "^2.86.0-4.0.0-beta.38",
+        "@girs/gnomebg-4.0": "^4.0.0-4.0.0-beta.38",
+        "@girs/gnomebluetooth-3.0": "^3.0.0-4.0.0-beta.38",
+        "@girs/gnomedesktop-4.0": "^4.0.0-4.0.0-beta.38",
+        "@girs/gobject-2.0": "^2.86.0-4.0.0-beta.38",
+        "@girs/gtk-4.0": "^4.20.1-4.0.0-beta.38",
+        "@girs/gvc-1.0": "^1.0.0-4.0.0-beta.38",
+        "@girs/meta-17": "^17.0.0-4.0.0-beta.38",
+        "@girs/mtk-17": "^17.0.0-4.0.0-beta.38",
+        "@girs/polkit-1.0": "^1.0.0-4.0.0-beta.38",
+        "@girs/shell-17": "^17.0.0-4.0.0-beta.38",
+        "@girs/shew-0": "^0.0.0-4.0.0-beta.38",
+        "@girs/st-17": "^17.0.0-4.0.0-beta.38",
+        "@girs/upowerglib-1.0": "^0.99.1-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/gnomebg-4.0": {
@@ -747,93 +335,6 @@
         "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
         "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
         "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gnomebg-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-543dlQheKHSVWIatqHNBiLceIWYzIJDXvofR3PfgarKMMi0IRkn1TndzxUxsLC4Eu24KgOKGZYjU1YPUMVGbgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gnomebg-4.0/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-hk6SG4pCcezKp2VNxJc0TC1gkZe3C8shD8sRQ3bUGyWl/9581WM2/8UU+W6fOf3SwXA1hquN6d3SjKbqkFNRKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gnomebg-4.0/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-L8NE18rhj100lRGMnf7lNUdr6pHw2co1UtExxDnglba5lNee4NoyF/u8g4Mk3toPU0fAu+ug91HJ4o2mIJd7MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gnomebg-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "11.5.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-11.5.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-XRf/neZYpEkinNZ8SCRKIao3RNVJzMeYcjuO1b1tbqVCrN7uVZ+MIaDW5NjWKi0K6IQSyZWdDgkzrtOrIN4CWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gnomebg-4.0/node_modules/@girs/pango-1.0": {
-      "version": "1.57.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-fnTzVVhKb4XjGrnuqk9X++KDe2bk84Hg5472O2UrtIT1A6dzMS6gWhSvaw0ULZH/Ypj9WN12B0oceWynR6unLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gnomebg-4.0/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-BY4rEgQW0H1c/24v+FGBjSZgZ6rk2Y4+ka9/WldUs74N1ZOh6nS4lHKUyy0antylQ7x0Fnw5UHgN0PbpdjkGuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/gnomebluetooth-3.0": {
@@ -864,19 +365,6 @@
         "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
       }
     },
-    "node_modules/@girs/gnomedesktop-4.0/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-L8NE18rhj100lRGMnf7lNUdr6pHw2co1UtExxDnglba5lNee4NoyF/u8g4Mk3toPU0fAu+ug91HJ4o2mIJd7MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
     "node_modules/@girs/gobject-2.0": {
       "version": "2.86.0-4.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.38.tgz",
@@ -888,167 +376,35 @@
       }
     },
     "node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-HVUsWooW82gaK6icqa7r4TtEtbyKTiCk99tjBaTDdFgizVljuaTY1QmTjtzHyxCx7vqGh2YtloIGtrZMkvjtCw==",
+      "version": "1.0.0-4.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.38.tgz",
+      "integrity": "sha512-zqCyLXFqsOJtCnwUR6lI6HBVdaJ6aKsA25y+6xK2dFO/NChOjH0hmBuVyTQiyLe+4jGW700o+uYIYlrpEXT/7Q==",
       "license": "MIT",
       "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/graphene-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-uQqDNDoDVALwSIRoW4I6Y9GXsQ9vkQLxB5kr2vQIskIW9fw6VExLpjPuyoVfRO8UqD3bU0d67uLWy6hCcnA0EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/graphene-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-rot40meT8+BuvcVDOQP02GZzWBH4pe4jO935g687jZ4mc0xkOFxDoxiSrif/+rb8VplDswKcu9AVQ1H59Z1Tiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/graphene-1.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Aj/QB0Eab8vkiP3doISBLAP6+GZhqBkc2EcjYymUxr/3VZpmpOTdFs4DFURUHKg4kkbwRfJSUrXEuTLSGcMfww==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/graphene-1.0/node_modules/@girs/glib-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Ljjr//wuJHjSE6UbuoYZ63I5u/qM1Am+fADzfJB2wUtelsfCjQVy7Gsucaef0oLW5nu9+kylLS+6LsQULx2ouw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/graphene-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-0SPLcXOwHauSWBoNZ/CtcmGd5Yn9NZYVgznMTGMnesWdUqD3BH5Ykdf9DTAEujxirJuLlxsPAH5lpR9zWRp8PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/graphene-1.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-UI35nVCQgjNvE+3Q+NeISsOOvynytagitURj2+hUGoCCp/BRMxqm6tUtX2hdhCeWUtd971/gLm78YjucAxRmWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37"
+        "@girs/gjs": "4.0.0-beta.38",
+        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/gsk-4.0": {
-      "version": "4.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-fzyM63F/eHSvVk2lmFM/EF4v49lquBbITum5gmGtoDPg0JAoS1OjW4tlRjzn77seDaaJAs8NpdlraVrndXHw4g==",
+      "version": "4.0.0-4.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.0-beta.38.tgz",
+      "integrity": "sha512-BfYpVfmKjD7Tq58W5p9fcU6Mvg3QcNRjJ1oQn05d/Xk1rjQmsk6tkcTkK3i/KIOhA9eVadQsMlFFWuN0KBE5Dw==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-beta.37",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.37",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.37",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gsk-4.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-uQqDNDoDVALwSIRoW4I6Y9GXsQ9vkQLxB5kr2vQIskIW9fw6VExLpjPuyoVfRO8UqD3bU0d67uLWy6hCcnA0EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gsk-4.0/node_modules/@girs/gio-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-rot40meT8+BuvcVDOQP02GZzWBH4pe4jO935g687jZ4mc0xkOFxDoxiSrif/+rb8VplDswKcu9AVQ1H59Z1Tiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gsk-4.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Aj/QB0Eab8vkiP3doISBLAP6+GZhqBkc2EcjYymUxr/3VZpmpOTdFs4DFURUHKg4kkbwRfJSUrXEuTLSGcMfww==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gsk-4.0/node_modules/@girs/glib-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Ljjr//wuJHjSE6UbuoYZ63I5u/qM1Am+fADzfJB2wUtelsfCjQVy7Gsucaef0oLW5nu9+kylLS+6LsQULx2ouw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gsk-4.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-0SPLcXOwHauSWBoNZ/CtcmGd5Yn9NZYVgznMTGMnesWdUqD3BH5Ykdf9DTAEujxirJuLlxsPAH5lpR9zWRp8PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/gsk-4.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-UI35nVCQgjNvE+3Q+NeISsOOvynytagitURj2+hUGoCCp/BRMxqm6tUtX2hdhCeWUtd971/gLm78YjucAxRmWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37"
+        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
+        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gdk-4.0": "4.0.0-4.0.0-beta.38",
+        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gjs": "4.0.0-beta.38",
+        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/graphene-1.0": "1.0.0-4.0.0-beta.38",
+        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
+        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
+        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/gtk-4.0": {
@@ -1073,125 +429,6 @@
         "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
       }
     },
-    "node_modules/@girs/gtk-4.0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-543dlQheKHSVWIatqHNBiLceIWYzIJDXvofR3PfgarKMMi0IRkn1TndzxUxsLC4Eu24KgOKGZYjU1YPUMVGbgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gtk-4.0/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-hk6SG4pCcezKp2VNxJc0TC1gkZe3C8shD8sRQ3bUGyWl/9581WM2/8UU+W6fOf3SwXA1hquN6d3SjKbqkFNRKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gtk-4.0/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-L8NE18rhj100lRGMnf7lNUdr6pHw2co1UtExxDnglba5lNee4NoyF/u8g4Mk3toPU0fAu+ug91HJ4o2mIJd7MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gtk-4.0/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-zqCyLXFqsOJtCnwUR6lI6HBVdaJ6aKsA25y+6xK2dFO/NChOjH0hmBuVyTQiyLe+4jGW700o+uYIYlrpEXT/7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gtk-4.0/node_modules/@girs/gsk-4.0": {
-      "version": "4.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-BfYpVfmKjD7Tq58W5p9fcU6Mvg3QcNRjJ1oQn05d/Xk1rjQmsk6tkcTkK3i/KIOhA9eVadQsMlFFWuN0KBE5Dw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-beta.38",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gtk-4.0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "11.5.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-11.5.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-XRf/neZYpEkinNZ8SCRKIao3RNVJzMeYcjuO1b1tbqVCrN7uVZ+MIaDW5NjWKi0K6IQSyZWdDgkzrtOrIN4CWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gtk-4.0/node_modules/@girs/pango-1.0": {
-      "version": "1.57.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-fnTzVVhKb4XjGrnuqk9X++KDe2bk84Hg5472O2UrtIT1A6dzMS6gWhSvaw0ULZH/Ypj9WN12B0oceWynR6unLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/gtk-4.0/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-BY4rEgQW0H1c/24v+FGBjSZgZ6rk2Y4+ka9/WldUs74N1ZOh6nS4lHKUyy0antylQ7x0Fnw5UHgN0PbpdjkGuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38"
-      }
-    },
     "node_modules/@girs/gvc-1.0": {
       "version": "1.0.0-4.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@girs/gvc-1.0/-/gvc-1.0-1.0.0-4.0.0-beta.38.tgz",
@@ -1206,81 +443,15 @@
       }
     },
     "node_modules/@girs/harfbuzz-0.0": {
-      "version": "11.5.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-11.5.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-nIToHOiiUjjYURRgobcPpjcUB4cPCxz5af5zf1ebWiw6hlpZY3P3NIzA4XXZspgmy375jsiWLel57ocsB+qq/Q==",
+      "version": "11.5.0-4.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-11.5.0-4.0.0-beta.38.tgz",
+      "integrity": "sha512-XRf/neZYpEkinNZ8SCRKIao3RNVJzMeYcjuO1b1tbqVCrN7uVZ+MIaDW5NjWKi0K6IQSyZWdDgkzrtOrIN4CWQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/harfbuzz-0.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-uQqDNDoDVALwSIRoW4I6Y9GXsQ9vkQLxB5kr2vQIskIW9fw6VExLpjPuyoVfRO8UqD3bU0d67uLWy6hCcnA0EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/harfbuzz-0.0/node_modules/@girs/gio-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-rot40meT8+BuvcVDOQP02GZzWBH4pe4jO935g687jZ4mc0xkOFxDoxiSrif/+rb8VplDswKcu9AVQ1H59Z1Tiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/harfbuzz-0.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Aj/QB0Eab8vkiP3doISBLAP6+GZhqBkc2EcjYymUxr/3VZpmpOTdFs4DFURUHKg4kkbwRfJSUrXEuTLSGcMfww==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/harfbuzz-0.0/node_modules/@girs/glib-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Ljjr//wuJHjSE6UbuoYZ63I5u/qM1Am+fADzfJB2wUtelsfCjQVy7Gsucaef0oLW5nu9+kylLS+6LsQULx2ouw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/harfbuzz-0.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-0SPLcXOwHauSWBoNZ/CtcmGd5Yn9NZYVgznMTGMnesWdUqD3BH5Ykdf9DTAEujxirJuLlxsPAH5lpR9zWRp8PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/harfbuzz-0.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-UI35nVCQgjNvE+3Q+NeISsOOvynytagitURj2+hUGoCCp/BRMxqm6tUtX2hdhCeWUtd971/gLm78YjucAxRmWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37"
+        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gjs": "4.0.0-beta.38",
+        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/meta-17": {
@@ -1309,55 +480,6 @@
         "@girs/xlib-2.0": "2.0.0-4.0.0-beta.38"
       }
     },
-    "node_modules/@girs/meta-17/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-543dlQheKHSVWIatqHNBiLceIWYzIJDXvofR3PfgarKMMi0IRkn1TndzxUxsLC4Eu24KgOKGZYjU1YPUMVGbgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/meta-17/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-zqCyLXFqsOJtCnwUR6lI6HBVdaJ6aKsA25y+6xK2dFO/NChOjH0hmBuVyTQiyLe+4jGW700o+uYIYlrpEXT/7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/meta-17/node_modules/@girs/harfbuzz-0.0": {
-      "version": "11.5.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-11.5.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-XRf/neZYpEkinNZ8SCRKIao3RNVJzMeYcjuO1b1tbqVCrN7uVZ+MIaDW5NjWKi0K6IQSyZWdDgkzrtOrIN4CWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/meta-17/node_modules/@girs/pango-1.0": {
-      "version": "1.57.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-fnTzVVhKb4XjGrnuqk9X++KDe2bk84Hg5472O2UrtIT1A6dzMS6gWhSvaw0ULZH/Ypj9WN12B0oceWynR6unLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38"
-      }
-    },
     "node_modules/@girs/mtk-17": {
       "version": "17.0.0-4.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@girs/mtk-17/-/mtk-17-17.0.0-4.0.0-beta.38.tgz",
@@ -1368,17 +490,6 @@
         "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
         "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
         "@girs/graphene-1.0": "1.0.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/mtk-17/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-zqCyLXFqsOJtCnwUR6lI6HBVdaJ6aKsA25y+6xK2dFO/NChOjH0hmBuVyTQiyLe+4jGW700o+uYIYlrpEXT/7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/nm-1.0": {
@@ -1395,168 +506,36 @@
       }
     },
     "node_modules/@girs/pango-1.0": {
-      "version": "1.57.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-yYd1/Sj/E2ZvuU5rDu9QP9cA/21s/npZLVQBaBLtSJ+YHzSJkF4RxXTv7ff+tirWTpHc9SiaULxXOFROOJlGog==",
+      "version": "1.57.0-4.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.0-4.0.0-beta.38.tgz",
+      "integrity": "sha512-fnTzVVhKb4XjGrnuqk9X++KDe2bk84Hg5472O2UrtIT1A6dzMS6gWhSvaw0ULZH/Ypj9WN12B0oceWynR6unLw==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pango-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-uQqDNDoDVALwSIRoW4I6Y9GXsQ9vkQLxB5kr2vQIskIW9fw6VExLpjPuyoVfRO8UqD3bU0d67uLWy6hCcnA0EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pango-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-rot40meT8+BuvcVDOQP02GZzWBH4pe4jO935g687jZ4mc0xkOFxDoxiSrif/+rb8VplDswKcu9AVQ1H59Z1Tiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pango-1.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Aj/QB0Eab8vkiP3doISBLAP6+GZhqBkc2EcjYymUxr/3VZpmpOTdFs4DFURUHKg4kkbwRfJSUrXEuTLSGcMfww==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pango-1.0/node_modules/@girs/glib-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Ljjr//wuJHjSE6UbuoYZ63I5u/qM1Am+fADzfJB2wUtelsfCjQVy7Gsucaef0oLW5nu9+kylLS+6LsQULx2ouw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pango-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-0SPLcXOwHauSWBoNZ/CtcmGd5Yn9NZYVgznMTGMnesWdUqD3BH5Ykdf9DTAEujxirJuLlxsPAH5lpR9zWRp8PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pango-1.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-UI35nVCQgjNvE+3Q+NeISsOOvynytagitURj2+hUGoCCp/BRMxqm6tUtX2hdhCeWUtd971/gLm78YjucAxRmWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37"
+        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
+        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gjs": "4.0.0-beta.38",
+        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-mcnyMEa15euqqo0AMGmFls2JWJgF1JxUxdQ5yrRAPLPn8ChjKesN16YfcXA6PCG7cmeBOb02MkjPEfqmcF0dAA==",
+      "version": "1.0.0-4.0.0-beta.38",
+      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-beta.38.tgz",
+      "integrity": "sha512-BY4rEgQW0H1c/24v+FGBjSZgZ6rk2Y4+ka9/WldUs74N1ZOh6nS4lHKUyy0antylQ7x0Fnw5UHgN0PbpdjkGuQ==",
       "license": "MIT",
       "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.37",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pangocairo-1.0/node_modules/@girs/cairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/cairo-1.0/-/cairo-1.0-1.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-uQqDNDoDVALwSIRoW4I6Y9GXsQ9vkQLxB5kr2vQIskIW9fw6VExLpjPuyoVfRO8UqD3bU0d67uLWy6hCcnA0EQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pangocairo-1.0/node_modules/@girs/gio-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gio-2.0/-/gio-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-rot40meT8+BuvcVDOQP02GZzWBH4pe4jO935g687jZ4mc0xkOFxDoxiSrif/+rb8VplDswKcu9AVQ1H59Z1Tiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pangocairo-1.0/node_modules/@girs/gjs": {
-      "version": "4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gjs/-/gjs-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Aj/QB0Eab8vkiP3doISBLAP6+GZhqBkc2EcjYymUxr/3VZpmpOTdFs4DFURUHKg4kkbwRfJSUrXEuTLSGcMfww==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.37",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pangocairo-1.0/node_modules/@girs/glib-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/glib-2.0/-/glib-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-Ljjr//wuJHjSE6UbuoYZ63I5u/qM1Am+fADzfJB2wUtelsfCjQVy7Gsucaef0oLW5nu9+kylLS+6LsQULx2ouw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pangocairo-1.0/node_modules/@girs/gmodule-2.0": {
-      "version": "2.0.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gmodule-2.0/-/gmodule-2.0-2.0.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-0SPLcXOwHauSWBoNZ/CtcmGd5Yn9NZYVgznMTGMnesWdUqD3BH5Ykdf9DTAEujxirJuLlxsPAH5lpR9zWRp8PA==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.37"
-      }
-    },
-    "node_modules/@girs/pangocairo-1.0/node_modules/@girs/gobject-2.0": {
-      "version": "2.86.0-4.0.0-beta.37",
-      "resolved": "https://registry.npmjs.org/@girs/gobject-2.0/-/gobject-2.0-2.86.0-4.0.0-beta.37.tgz",
-      "integrity": "sha512-UI35nVCQgjNvE+3Q+NeISsOOvynytagitURj2+hUGoCCp/BRMxqm6tUtX2hdhCeWUtd971/gLm78YjucAxRmWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.37",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.37"
+        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
+        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gjs": "4.0.0-beta.38",
+        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
+        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
+        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
+        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/polkit-1.0": {
@@ -1622,68 +601,6 @@
         "@girs/xlib-2.0": "2.0.0-4.0.0-beta.38"
       }
     },
-    "node_modules/@girs/shell-17/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-543dlQheKHSVWIatqHNBiLceIWYzIJDXvofR3PfgarKMMi0IRkn1TndzxUxsLC4Eu24KgOKGZYjU1YPUMVGbgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shell-17/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-L8NE18rhj100lRGMnf7lNUdr6pHw2co1UtExxDnglba5lNee4NoyF/u8g4Mk3toPU0fAu+ug91HJ4o2mIJd7MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shell-17/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-zqCyLXFqsOJtCnwUR6lI6HBVdaJ6aKsA25y+6xK2dFO/NChOjH0hmBuVyTQiyLe+4jGW700o+uYIYlrpEXT/7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shell-17/node_modules/@girs/harfbuzz-0.0": {
-      "version": "11.5.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-11.5.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-XRf/neZYpEkinNZ8SCRKIao3RNVJzMeYcjuO1b1tbqVCrN7uVZ+MIaDW5NjWKi0K6IQSyZWdDgkzrtOrIN4CWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shell-17/node_modules/@girs/pango-1.0": {
-      "version": "1.57.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-fnTzVVhKb4XjGrnuqk9X++KDe2bk84Hg5472O2UrtIT1A6dzMS6gWhSvaw0ULZH/Ypj9WN12B0oceWynR6unLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38"
-      }
-    },
     "node_modules/@girs/shew-0": {
       "version": "0.0.0-4.0.0-beta.38",
       "resolved": "https://registry.npmjs.org/@girs/shew-0/-/shew-0-0.0.0-4.0.0-beta.38.tgz",
@@ -1705,125 +622,6 @@
         "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
         "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
         "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shew-0/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-543dlQheKHSVWIatqHNBiLceIWYzIJDXvofR3PfgarKMMi0IRkn1TndzxUxsLC4Eu24KgOKGZYjU1YPUMVGbgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shew-0/node_modules/@girs/gdk-4.0": {
-      "version": "4.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gdk-4.0/-/gdk-4.0-4.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-hk6SG4pCcezKp2VNxJc0TC1gkZe3C8shD8sRQ3bUGyWl/9581WM2/8UU+W6fOf3SwXA1hquN6d3SjKbqkFNRKg==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shew-0/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-L8NE18rhj100lRGMnf7lNUdr6pHw2co1UtExxDnglba5lNee4NoyF/u8g4Mk3toPU0fAu+ug91HJ4o2mIJd7MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shew-0/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-zqCyLXFqsOJtCnwUR6lI6HBVdaJ6aKsA25y+6xK2dFO/NChOjH0hmBuVyTQiyLe+4jGW700o+uYIYlrpEXT/7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shew-0/node_modules/@girs/gsk-4.0": {
-      "version": "4.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gsk-4.0/-/gsk-4.0-4.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-BfYpVfmKjD7Tq58W5p9fcU6Mvg3QcNRjJ1oQn05d/Xk1rjQmsk6tkcTkK3i/KIOhA9eVadQsMlFFWuN0KBE5Dw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gdk-4.0": "4.0.0-4.0.0-beta.38",
-        "@girs/gdkpixbuf-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/graphene-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
-        "@girs/pangocairo-1.0": "1.0.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shew-0/node_modules/@girs/harfbuzz-0.0": {
-      "version": "11.5.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-11.5.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-XRf/neZYpEkinNZ8SCRKIao3RNVJzMeYcjuO1b1tbqVCrN7uVZ+MIaDW5NjWKi0K6IQSyZWdDgkzrtOrIN4CWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shew-0/node_modules/@girs/pango-1.0": {
-      "version": "1.57.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-fnTzVVhKb4XjGrnuqk9X++KDe2bk84Hg5472O2UrtIT1A6dzMS6gWhSvaw0ULZH/Ypj9WN12B0oceWynR6unLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/shew-0/node_modules/@girs/pangocairo-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/pangocairo-1.0/-/pangocairo-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-BY4rEgQW0H1c/24v+FGBjSZgZ6rk2Y4+ka9/WldUs74N1ZOh6nS4lHKUyy0antylQ7x0Fnw5UHgN0PbpdjkGuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38",
-        "@girs/pango-1.0": "1.57.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/st-17": {
@@ -1852,68 +650,6 @@
         "@girs/pango-1.0": "1.57.0-4.0.0-beta.38",
         "@girs/xfixes-4.0": "4.0.0-4.0.0-beta.38",
         "@girs/xlib-2.0": "2.0.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/st-17/node_modules/@girs/freetype2-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/freetype2-2.0/-/freetype2-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-543dlQheKHSVWIatqHNBiLceIWYzIJDXvofR3PfgarKMMi0IRkn1TndzxUxsLC4Eu24KgOKGZYjU1YPUMVGbgg==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/st-17/node_modules/@girs/gdkpixbuf-2.0": {
-      "version": "2.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/gdkpixbuf-2.0/-/gdkpixbuf-2.0-2.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-L8NE18rhj100lRGMnf7lNUdr6pHw2co1UtExxDnglba5lNee4NoyF/u8g4Mk3toPU0fAu+ug91HJ4o2mIJd7MQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/st-17/node_modules/@girs/graphene-1.0": {
-      "version": "1.0.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/graphene-1.0/-/graphene-1.0-1.0.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-zqCyLXFqsOJtCnwUR6lI6HBVdaJ6aKsA25y+6xK2dFO/NChOjH0hmBuVyTQiyLe+4jGW700o+uYIYlrpEXT/7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/st-17/node_modules/@girs/harfbuzz-0.0": {
-      "version": "11.5.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/harfbuzz-0.0/-/harfbuzz-0.0-11.5.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-XRf/neZYpEkinNZ8SCRKIao3RNVJzMeYcjuO1b1tbqVCrN7uVZ+MIaDW5NjWKi0K6IQSyZWdDgkzrtOrIN4CWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38"
-      }
-    },
-    "node_modules/@girs/st-17/node_modules/@girs/pango-1.0": {
-      "version": "1.57.0-4.0.0-beta.38",
-      "resolved": "https://registry.npmjs.org/@girs/pango-1.0/-/pango-1.0-1.57.0-4.0.0-beta.38.tgz",
-      "integrity": "sha512-fnTzVVhKb4XjGrnuqk9X++KDe2bk84Hg5472O2UrtIT1A6dzMS6gWhSvaw0ULZH/Ypj9WN12B0oceWynR6unLw==",
-      "license": "MIT",
-      "dependencies": {
-        "@girs/cairo-1.0": "1.0.0-4.0.0-beta.38",
-        "@girs/freetype2-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gio-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gjs": "4.0.0-beta.38",
-        "@girs/glib-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/gmodule-2.0": "2.0.0-4.0.0-beta.38",
-        "@girs/gobject-2.0": "2.86.0-4.0.0-beta.38",
-        "@girs/harfbuzz-0.0": "11.5.0-4.0.0-beta.38"
       }
     },
     "node_modules/@girs/upowerglib-1.0": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   },
   "dependencies": {
     "@girs/gjs": "^4.0.0-beta.38",
-    "@girs/gnome-shell": "^49.0.1"
+    "@girs/gnome-shell": "^49.1.0"
   }
 }

--- a/src/features/overlayMenu.ts
+++ b/src/features/overlayMenu.ts
@@ -39,10 +39,14 @@ export class OverlayMenu extends FeatureBase {
 		const targetHeight = outerHeight - menu.box.marginTop
 		let offsetY: number
 		if (Global.QuickSettingsBox.height < targetHeight && this.overflowAnchor != "center") {
+			// When menu is taller than Quick Settings box and anchor is set
 			if (this.overflowAnchor == "top") {
+				// Top anchor: menu top aligns with box top, overflows downward
 				offsetY = 0
 			} else {
-				offsetY = Global.QuickSettingsBox.height - targetHeight
+				// Bottom anchor: menu bottom aligns with box bottom, overflows upward
+				// Ensure offsetY doesn't go negative to prevent menu from positioning above the box
+				offsetY = Math.max(0, Global.QuickSettingsBox.height - targetHeight)
 			}
 		} else {
 			offsetY = Math.floor((Global.QuickSettingsBox.height - targetHeight) / 2)

--- a/src/features/widget/media.ts
+++ b/src/features/widget/media.ts
@@ -736,8 +736,9 @@ class MediaItem extends MessageList.Message {
 	}
 
 	addEventStop<T extends Clutter.Actor>(actor: T): T {
-		// actor.connect("button-press-event", ()=>Clutter.EVENT_STOP);
-		return actor;
+		actor.connect("button-press-event", () => Clutter.EVENT_STOP)
+		actor.connect("button-release-event", () => Clutter.EVENT_STOP)
+		return actor
 	}
 }
 GObject.registerClass(MediaItem)


### PR DESCRIPTION
## Summary
This PR adds GNOME 49 compatibility by replacing deprecated APIs and fixing bugs.

## Changes

### GNOME 49 Compatibility
- Replace deprecated `DoNotDisturbSwitch` from `ui/calendar.js` with custom implementation
- Use `St.Button` with `toggle_mode` instead of non-existent `St.Switch`
- Use direct `Gio.Settings` access for `org.gnome.desktop.notifications` schema
- Add proper cleanup on destroy to prevent memory leaks

### Bug Fixes
- **overlayMenu.ts**: Fix negative `offsetY` when "bottom" anchor is used with oversized menu
- **media.ts**: Enable `addEventStop` functionality (was commented out/no-op)

## Testing
- Tested on GNOME 49 (openSUSE Tumbleweed)
- Extension loads without errors
- DND toggle works correctly

## Reference
- [GNOME Shell 49 Porting Guide](https://gjs.guide/extensions/upgrading/gnome-shell-49.html)