### PR TITLE
Fix #177, volume mixer can now be disabled

### DIFF
--- a/src/features/widget/volumeMixer.ts
+++ b/src/features/widget/volumeMixer.ts
@@ -648,6 +648,7 @@ export class VolumeMixerWidgetFeature extends FeatureBase {
 		this.maid.destroyJob(
 			this.volumeMixerWidget = new VolumeMixerWidget(this)
 		)
+		if (!this.enabled) return
 		if (this.menuEnabled) {
 			Global.GetStreamSlider().then(
 				({ OutputStreamSlider }) => this.createMenu(OutputStreamSlider)


### PR DESCRIPTION
The title and the only line added that you can see in the files changed section pretty much explain the fix, there was no check on whether the mixer should be visible/enabled or not (unlike the other widgets in which that very line was present).